### PR TITLE
Download pages

### DIFF
--- a/src/components/Download/Download.css
+++ b/src/components/Download/Download.css
@@ -291,6 +291,10 @@
       display: flex;
       justify-content: space-between;
 
+      @media (--mobile-viewport) {
+        flex-direction: column;
+      }
+
       @media (--tablet-viewport) {
         justify-content: flex-start;
       }
@@ -302,19 +306,14 @@
 
       @media (--mobile-viewport) {
         min-width: 280px;
+        margin: 20px 0;
 
         &.mobile--ios {
-          .current--android & {
-            display: none;
-          }
+          display: block;
         }
 
         &.mobile--android {
-          display: none;
-
-          .current--android & {
-            display: block;
-          }
+          display: block;
         }
       }
 

--- a/src/components/Download/Download.js
+++ b/src/components/Download/Download.js
@@ -9,7 +9,7 @@ import { DownloadWeb } from './DownloadWeb';
 
 import './Download.css';
 
-export function Download({ openOfferModal }) {
+export function Download({ openOfferModal, locale }) {
   return (
     <Section className="download download__sections">
       <section className="download__section download__intro">
@@ -25,7 +25,7 @@ export function Download({ openOfferModal }) {
       </section>
 
       <DownloadDesktop />
-      <DownloadMobile />
+      <DownloadMobile locale={locale} />
       <DownloadWeb />
     </Section>
   );

--- a/src/components/Download/DownloadMobile.js
+++ b/src/components/Download/DownloadMobile.js
@@ -6,7 +6,7 @@ import ImageFormatted from '../ImageFormatted';
 import { getOS } from '../../utils/getOS';
 import appLinks from '../../constants/links';
 
-export function DownloadMobile({ isEnterprise }) {
+export function DownloadMobile({ isEnterprise, locale }) {
   function handleDownloadAnalytics(event, param) {
     if (typeof window !== 'undefined') {
       window.ga('dlg.send', 'event', 'button', 'download', `${param}`);
@@ -14,13 +14,8 @@ export function DownloadMobile({ isEnterprise }) {
     }
   }
 
-  const os = getOS();
   const links = isEnterprise ? appLinks.enterprise : appLinks.cloud;
-
-  const mobileClasses = classnames(
-    'download__mobile-items',
-    'current--' + os.toLowerCase(),
-  );
+  const mobileClasses = classnames('download__mobile-items');
 
   return (
     <section className="download__section download__item download__mobile">
@@ -43,7 +38,15 @@ export function DownloadMobile({ isEnterprise }) {
               }
             />
           </div>
-          <div className="title">iPhone / iPad</div>
+          <div className="title">
+            <a
+              className="download__item-link"
+              href={locale === 'ru' ? links.ios : links.ios_en}
+              onClick={(event) => handleDownloadAnalytics(event, 'dialog_ios')}
+            >
+              iPhone / iPad
+            </a>
+          </div>
           <div className="qr-box">
             <ImageFormatted
               src={
@@ -60,7 +63,7 @@ export function DownloadMobile({ isEnterprise }) {
           </div>
           <a
             className="store-link"
-            href={links.ios}
+            href={locale === 'ru' ? links.ios : links.ios_en}
             onClick={(event) => handleDownloadAnalytics(event, 'dialog_ios')}
           >
             <ImageFormatted
@@ -86,7 +89,17 @@ export function DownloadMobile({ isEnterprise }) {
               }
             />
           </div>
-          <div className="title">Android</div>
+          <div className="title">
+            <a
+              className="download__item-link"
+              href={links.android}
+              onClick={(event) =>
+                handleDownloadAnalytics(event, 'dialog_android')
+              }
+            >
+              Android
+            </a>
+          </div>
           <div className="qr-box">
             <ImageFormatted
               src={

--- a/src/components/DownloadEnterprise/DownloadEnterprise.js
+++ b/src/components/DownloadEnterprise/DownloadEnterprise.js
@@ -7,7 +7,7 @@ import { DownloadDesktop } from '../Download/DownloadDesktop';
 import { DownloadMobile } from '../Download/DownloadMobile';
 import { DownloadWeb } from '../Download/DownloadWeb';
 
-export function DownloadEnterprise() {
+export function DownloadEnterprise({ locale }) {
   return (
     <Section className="download download__sections">
       <section className="download__section download__intro">
@@ -22,7 +22,7 @@ export function DownloadEnterprise() {
       </section>
 
       <DownloadDesktop isEnterprise />
-      <DownloadMobile isEnterprise />
+      <DownloadMobile isEnterprise locale={locale} />
       <DownloadWeb isEnterprise />
     </Section>
   );

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -1,6 +1,7 @@
 module.exports = {
   cloud: {
-    ios: 'https://itunes.apple.com/us/app/dialog-messenger/id1134796870',
+    ios: 'https://itunes.apple.com/ru/app/dialog-messenger/id1134796870',
+    ios_en: 'https://itunes.apple.com/app/dialog-messenger/id1134796870',
     android: 'https://play.google.com/store/apps/details?id=im.dlg.app',
     web: 'https://app.dlg.im',
     osx: 'https://cdn1.dlg.im/desktop/dialog-messenger-mac-latest.zip',
@@ -10,8 +11,9 @@ module.exports = {
       'https://cdn1.dlg.im/desktop/dialog-messenger-linux-amd64-latest.deb',
   },
   enterprise: {
-    ios: 'https://itunes.apple.com/us/app/dialog-enterprise/id1210727252',
-    android: 'https://play.google.com/store/apps/details?id=im.dlg.ee',
+    ios: 'https://itunes.apple.com/ru/app/dialog-in-company/id1438225210',
+    ios_en: 'https://itunes.apple.com/app/dialog-in-company/id1438225210',
+    android: 'https://play.google.com/store/apps/details?id=im.dlg.ee.grpc',
     web: 'https://ee.dlg.im',
     osx:
       'https://dialog-ee-desktop.s3.amazonaws.com/dialog-ee-messenger-mac-latest.zip',

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -20,7 +20,7 @@ export default ({ pageContext: { locale, url, originalPath } }) => {
       />
 
       <Container>
-        <Download />
+        <Download locale={locale} />
       </Container>
     </Page>
   );

--- a/src/pages/download/enterprise.js
+++ b/src/pages/download/enterprise.js
@@ -20,7 +20,7 @@ export default ({ pageContext: { locale, url, originalPath } }) => {
       />
 
       <Container>
-        <DownloadEnterprise />
+        <DownloadEnterprise locale={locale} />
       </Container>
     </Page>
   );


### PR DESCRIPTION
ТЗ:
#1. На страницах 1 (https://dlg.im/ru/download/enterprise) и 2 (https://dlg.im/ru/download/) на разрешениях, где определяется одно мобильное приложение исключить автоопределение девайса и вместо этого показывать сразу 2 мобильных приложения. То есть будет порядок: 
1. Заголовок ("Мобильное приложение")
2. Интерфейс приложения с айфоном
3. Кнопка "Download on the App Store"
4. Интерфейс приложения с андроидом
5. Кнопка "Get it on Google Play" 
Остальные элементы менять не нужно.

#2 Добавить ссылки на названия платформ (ссылки по стилю как эти http://prntscr.com/nlil30) : 
1-ая Страница: https://dlg.im/ru/download/enterprise
Ссылки:
https://itunes.apple.com/ru/app/dialog-in-company/id1438225210
https://play.google.com/store/apps/details?id=im.dlg.ee.grpc


2-ая Страница: https://dlg.im/ru/download/
Ссылки:
https://itunes.apple.com/ru/app/dialog-messenger/id1134796870
https://play.google.com/store/apps/details?id=im.dlg.app

+ на декстоп версии надо название платформы выделить ссылками
